### PR TITLE
Add async event bus and integrate scheduler

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -378,6 +378,10 @@ class Agent:
                             # process tools requested in agent message
                             tools_result = await self.process_tools(agent_response)
                             if tools_result:  # final response of message loop available
+                                from python.helpers.event_bus import AsyncEventBus
+                                AsyncEventBus.get().emit(
+                                    "agent.response", tools_result, self.context
+                                )
                                 return tools_result  # break the execution if the task is done
 
                     # exceptions inside message loop:

--- a/python/helpers/event_bus.py
+++ b/python/helpers/event_bus.py
@@ -1,0 +1,17 @@
+import asyncio
+from pyee import AsyncIOEventEmitter
+
+
+class AsyncEventBus(AsyncIOEventEmitter):
+    """Singleton event bus based on AsyncIOEventEmitter."""
+
+    _instance: "AsyncEventBus" | None = None
+
+    def __init__(self) -> None:
+        super().__init__(loop=asyncio.get_event_loop())
+
+    @classmethod
+    def get(cls) -> "AsyncEventBus":
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance

--- a/python/helpers/job_loop.py
+++ b/python/helpers/job_loop.py
@@ -1,10 +1,10 @@
 import asyncio
-from datetime import datetime
 import time
 from python.helpers.task_scheduler import TaskScheduler
 from python.helpers.print_style import PrintStyle
 from python.helpers import errors
 from python.helpers import runtime
+from python.helpers.event_bus import AsyncEventBus
 
 
 SLEEP_TIME = 60
@@ -16,22 +16,33 @@ pause_time = 0
 async def run_loop():
     global pause_time, keep_running
 
-    while True:
+    scheduler = TaskScheduler.get()
+    bus = AsyncEventBus.get()
+
+    async def handle_event(*args, **kwargs):
         if runtime.is_development():
-            # Signal to container that the job loop should be paused
-            # if we are runing a development instance to avoid duble-running the jobs
             try:
                 await runtime.call_development_function(pause_loop)
             except Exception as e:
-                PrintStyle().error("Failed to pause job loop by development instance: " + errors.error_text(e))
+                PrintStyle().error(
+                    "Failed to pause job loop by development instance: "
+                    + errors.error_text(e)
+                )
         if not keep_running and (time.time() - pause_time) > (SLEEP_TIME * 2):
             resume_loop()
         if keep_running:
             try:
-                await scheduler_tick()
+                await scheduler.tick()
             except Exception as e:
                 PrintStyle().error(errors.format_error(e))
-        await asyncio.sleep(SLEEP_TIME)  # TODO! - if we lower it under 1min, it can run a 5min job multiple times in it's target minute
+
+    bus.on(
+        "task.finished",
+        lambda *a, **k: asyncio.create_task(handle_event(*a, **k)),
+    )
+
+    await handle_event()
+    await asyncio.Event().wait()
 
 
 async def scheduler_tick():

--- a/python/helpers/task_scheduler.py
+++ b/python/helpers/task_scheduler.py
@@ -837,6 +837,10 @@ class TaskScheduler:
                 self._printer.print(f"Scheduler Task '{current_task.name}' completed: {result}")
                 await self._persist_chat(current_task, context)
                 await current_task.on_success(result)
+                from python.helpers.event_bus import AsyncEventBus
+                AsyncEventBus.get().emit(
+                    "task.finished", current_task, result, None
+                )
 
                 # Explicitly verify task was updated in storage after success
                 await self._tasks.reload()
@@ -849,6 +853,10 @@ class TaskScheduler:
                 # Error
                 self._printer.print(f"Scheduler Task '{current_task.name}' failed: {e}")
                 await current_task.on_error(str(e))
+                from python.helpers.event_bus import AsyncEventBus
+                AsyncEventBus.get().emit(
+                    "task.finished", current_task, None, str(e)
+                )
 
                 # Explicitly verify task was updated in storage after error
                 await self._tasks.reload()

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ pathspec>=0.12.1
 psutil>=7.0.0
 pytest>=8.0
 pytest-cov>=5.0
+pyee==13.0.0

--- a/run_ui.py
+++ b/run_ui.py
@@ -242,6 +242,7 @@ def init_a0():
     initialize.initialize_mcp()
     # start job loop
     initialize.initialize_job_loop()
+    initialize.initialize_event_listeners()
 
     # only wait for init chats, otherwise they would seem to dissapear for a while on restart
     init_chats.result_sync()


### PR DESCRIPTION
## Summary
- add `AsyncEventBus` singleton
- emit `agent.response` events when an agent finishes
- emit `task.finished` events from the scheduler
- convert job loop to respond to `task.finished`
- register sample event listeners during initialization
- include pyee in requirements

## Testing
- `python -m py_compile agent.py python/helpers/task_scheduler.py python/helpers/job_loop.py initialize.py run_ui.py python/helpers/event_bus.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863204da2e88328b02c29854d78e841