### PR TITLE
Implement cron scheduler

### DIFF
--- a/python/api/scheduler_task_create.py
+++ b/python/api/scheduler_task_create.py
@@ -56,11 +56,12 @@ class SchedulerTaskCreate(ApiHandler):
                 # Parse the string schedule
                 parts = schedule.split(' ')
                 task_schedule = TaskSchedule(
-                    minute=parts[0] if len(parts) > 0 else "*",
-                    hour=parts[1] if len(parts) > 1 else "*",
-                    day=parts[2] if len(parts) > 2 else "*",
-                    month=parts[3] if len(parts) > 3 else "*",
-                    weekday=parts[4] if len(parts) > 4 else "*"
+                    second=parts[0] if len(parts) > 0 else "0",
+                    minute=parts[1] if len(parts) > 1 else "*",
+                    hour=parts[2] if len(parts) > 2 else "*",
+                    day=parts[3] if len(parts) > 3 else "*",
+                    month=parts[4] if len(parts) > 4 else "*",
+                    weekday=parts[5] if len(parts) > 5 else "*"
                 )
             elif isinstance(schedule, dict):
                 # Use our standardized parsing function

--- a/python/helpers/job_loop.py
+++ b/python/helpers/job_loop.py
@@ -1,16 +1,58 @@
 import asyncio
 import time
-from python.helpers.task_scheduler import TaskScheduler
+from typing import Dict
+
+import aiocron
+import pytz
+
+from python.helpers.task_scheduler import TaskScheduler, ScheduledTask
 from python.helpers.print_style import PrintStyle
 from python.helpers import errors
 from python.helpers import runtime
 from python.helpers.event_bus import AsyncEventBus
+from python.helpers.localization import Localization
 
-
-SLEEP_TIME = 60
 
 keep_running = True
 pause_time = 0
+cron_jobs: Dict[str, aiocron.Cron] = {}
+
+
+async def schedule_jobs() -> None:
+    scheduler = TaskScheduler.get()
+    await scheduler.reload()
+    tasks = scheduler.get_tasks()
+
+    # Remove jobs for deleted tasks
+    for uuid in list(cron_jobs.keys()):
+        if not any(t.uuid == uuid for t in tasks if isinstance(t, ScheduledTask)):
+            cron_jobs[uuid].stop()
+            del cron_jobs[uuid]
+
+    for task in tasks:
+        if isinstance(task, ScheduledTask):
+            cron_expr = task.schedule.to_crontab()
+            tz = pytz.timezone(task.schedule.timezone or Localization.get().get_timezone())
+            job = cron_jobs.get(task.uuid)
+            if job and job.spec == cron_expr and job.tz == tz:
+                continue
+            if job:
+                job.stop()
+            cron_jobs[task.uuid] = aiocron.crontab(
+                cron_expr,
+                func=lambda uuid=task.uuid: asyncio.create_task(run_scheduled(uuid)),
+                start=True,
+                tz=tz,
+            )
+
+
+async def run_scheduled(task_uuid: str) -> None:
+    if keep_running:
+        try:
+            scheduler = TaskScheduler.get()
+            await scheduler.run_task_by_uuid(task_uuid)
+        except Exception as e:
+            PrintStyle().error(errors.format_error(e))
 
 
 async def run_loop():
@@ -28,19 +70,21 @@ async def run_loop():
                     "Failed to pause job loop by development instance: "
                     + errors.error_text(e)
                 )
-        if not keep_running and (time.time() - pause_time) > (SLEEP_TIME * 2):
+        if not keep_running and (time.time() - pause_time) > 120:
             resume_loop()
         if keep_running:
             try:
                 await scheduler.tick()
             except Exception as e:
                 PrintStyle().error(errors.format_error(e))
+        await schedule_jobs()
 
     bus.on(
         "task.finished",
         lambda *a, **k: asyncio.create_task(handle_event(*a, **k)),
     )
 
+    await schedule_jobs()
     await handle_event()
     await asyncio.Event().wait()
 

--- a/python/helpers/task_scheduler.py
+++ b/python/helpers/task_scheduler.py
@@ -46,6 +46,7 @@ class TaskType(str, Enum):
 
 
 class TaskSchedule(BaseModel):
+    second: str = "0"
     minute: str
     hour: str
     day: str
@@ -54,7 +55,9 @@ class TaskSchedule(BaseModel):
     timezone: str = Field(default_factory=lambda: Localization.get().get_timezone())
 
     def to_crontab(self) -> str:
-        return f"{self.minute} {self.hour} {self.day} {self.month} {self.weekday}"
+        return (
+            f"{self.second} {self.minute} {self.hour} {self.day} {self.month} {self.weekday}"
+        )
 
 
 class TaskPlan(BaseModel):
@@ -938,6 +941,7 @@ def parse_datetime(dt_str: Optional[str]) -> Optional[datetime]:
 def serialize_task_schedule(schedule: TaskSchedule) -> Dict[str, str]:
     """Convert TaskSchedule to a standardized dictionary format."""
     return {
+        'second': schedule.second,
         'minute': schedule.minute,
         'hour': schedule.hour,
         'day': schedule.day,
@@ -951,6 +955,7 @@ def parse_task_schedule(schedule_data: Dict[str, str]) -> TaskSchedule:
     """Parse dictionary into TaskSchedule with validation."""
     try:
         return TaskSchedule(
+            second=schedule_data.get('second', '0'),
             minute=schedule_data.get('minute', '*'),
             hour=schedule_data.get('hour', '*'),
             day=schedule_data.get('day', '*'),

--- a/python/tools/scheduler.py
+++ b/python/tools/scheduler.py
@@ -141,6 +141,7 @@ class SchedulerTool(Tool):
         dedicated_context: bool = kwargs.get("dedicated_context", False)
 
         task_schedule = TaskSchedule(
+            second=schedule.get("second", "0"),
             minute=schedule.get("minute", "*"),
             hour=schedule.get("hour", "*"),
             day=schedule.get("day", "*"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ pytest-cov>=5.0
 pyee==13.0.0
 networkx==3.3
 nats-py==2.6.0
+aiocron==2.1

--- a/tests/test_job_loop_cron.py
+++ b/tests/test_job_loop_cron.py
@@ -1,0 +1,62 @@
+import asyncio
+import time
+import pytest
+
+import sys
+import types
+
+from python.helpers.task_scheduler import TaskScheduler, ScheduledTask, TaskSchedule
+
+dummy_pyee = types.ModuleType('pyee')
+class _DummyEmitter:
+    def __init__(self, *a, **k):
+        pass
+sys.modules.setdefault('pyee', dummy_pyee)
+dummy_pyee.AsyncIOEventEmitter = _DummyEmitter
+
+dummy_event_bus = types.ModuleType('python.helpers.event_bus')
+class _DummyEventBus:
+    @classmethod
+    def get(cls):
+        return cls()
+    def on(self, *a, **k):
+        pass
+    def emit(self, *a, **k):
+        pass
+dummy_event_bus.AsyncEventBus = _DummyEventBus
+sys.modules['python.helpers.event_bus'] = dummy_event_bus
+
+from python.helpers.job_loop import cron_jobs, schedule_jobs, resume_loop
+
+def test_no_duplicate_runs_for_subminute(monkeypatch, tmp_path):
+    async def _run():
+        monkeypatch.setattr('python.helpers.task_scheduler.SCHEDULER_FOLDER', str(tmp_path))
+        scheduler = TaskScheduler.get()
+        await scheduler._tasks.save()
+
+        schedule = TaskSchedule(second='*/1', minute='*', hour='*', day='*', month='*', weekday='*')
+        task = ScheduledTask.create(name='t', system_prompt='', prompt='', schedule=schedule)
+        await scheduler.add_task(task)
+
+        calls = []
+
+        async def fake_run(uuid):
+            calls.append(time.time())
+
+        monkeypatch.setattr(TaskScheduler, 'run_task_by_uuid', lambda self, uuid: fake_run(uuid))
+
+        resume_loop()
+        await schedule_jobs()
+
+        start = time.time()
+        for _ in range(4):
+            await asyncio.sleep(0.5)
+            await schedule_jobs()
+        elapsed = time.time() - start
+
+        for job in cron_jobs.values():
+            job.stop()
+
+        assert len(calls) <= int(elapsed) + 1
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- support second-level cron configuration via `TaskSchedule`
- schedule jobs individually with `aiocron` and remove static sleep
- adjust scheduler creation helpers for new field
- add test ensuring no duplicate cron executions

## Testing
- `PYTHONPATH=. pytest tests/test_job_loop_cron.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68646689074883289e302ff1ed2ad601