### PR TITLE
Add log event emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,20 @@ Set `NATS_URL` in your `.env` to enable a distributed event bus for multi-proces
 scaling. When configured, background workers and the UI communicate over NATS so
 you can run components separately.
 
+### 🔔 Log Event Listeners
+
+Every call to `python/helpers/log.py` emits a `log.record` event via the bus.
+Subscribe your own callbacks for custom monitoring or analytics:
+
+```python
+from python.helpers.event_bus import AsyncEventBus
+
+bus = AsyncEventBus.get()
+bus.on("log.record", lambda record: print(record))
+```
+
+The default `StructuredLogListener` stores JSON Lines in `logs/events.jsonl`.
+
 ## 🐳 Fully Dockerized, with Speech-to-Text and TTS
 
 ![Settings](docs/res/settings-page-ui.png)

--- a/initialize.py
+++ b/initialize.py
@@ -124,12 +124,15 @@ def initialize_event_listeners():
     import asyncio
     from python.helpers.event_bus import AsyncEventBus
     from python.helpers.graph_worker import KnowledgeGraphWorker
+    from python.helpers.log_listener import StructuredLogListener
 
     bus = AsyncEventBus.get()
     # ensure NATS connection
     asyncio.create_task(bus._connect_nats())
     # start knowledge graph worker to track messages
     KnowledgeGraphWorker()
+    # persist logs to file by default
+    StructuredLogListener()
 
     async def _print_agent_response(response: str, context):
         PrintStyle(font_color="cyan", padding=False).print(

--- a/python/helpers/log.py
+++ b/python/helpers/log.py
@@ -4,6 +4,7 @@ from typing import Any, Literal, Optional, Dict
 import uuid
 from collections import OrderedDict  # Import OrderedDict
 
+
 Type = Literal[
     "agent",
     "browser",
@@ -94,6 +95,8 @@ class Log:
         self.guid: str = str(uuid.uuid4())
         self.updates: list[int] = []
         self.logs: list[LogItem] = []
+        from python.helpers.event_bus import AsyncEventBus
+        self.bus = AsyncEventBus.get()
         self.set_initial_progress()
 
     def log(
@@ -126,6 +129,10 @@ class Log:
         self.logs.append(item)
         self.updates += [item.no]
         self._update_progress_from_item(item)
+        try:
+            self.bus.emit("log.record", item.output())
+        except Exception:
+            pass
         return item
 
     def _update_item(

--- a/python/helpers/log_listener.py
+++ b/python/helpers/log_listener.py
@@ -1,0 +1,25 @@
+import asyncio
+import json
+import os
+
+from python.helpers.event_bus import AsyncEventBus
+
+
+class StructuredLogListener:
+    """Default listener that writes log events to a JSONL file."""
+
+    def __init__(self, logfile: str = "logs/events.jsonl") -> None:
+        self.logfile = logfile
+        os.makedirs(os.path.dirname(self.logfile), exist_ok=True)
+        self._lock = asyncio.Lock()
+        bus = AsyncEventBus.get()
+        bus.on("log.record", lambda record: asyncio.create_task(self._write(record)))
+
+    async def _write(self, record: dict) -> None:
+        async with self._lock:
+            try:
+                with open(self.logfile, "a", encoding="utf-8") as f:
+                    json.dump(record, f)
+                    f.write("\n")
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- emit `log.record` on event bus whenever a new log item is created
- persist logs via new `StructuredLogListener`
- initialize log listener with other event listeners
- document subscribing to log events

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658cd5fe348328b3b95358f3b99ea0