### PR TITLE
Add event bus tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -vv

--- a/python/helpers/event_bus.py
+++ b/python/helpers/event_bus.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import os
 import pickle

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,96 @@
 import os
 import sys
+import threading
+from typing import Generator
 
 # Ensure project root is on sys.path for tests
-ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
+
+import pytest
+from flask import Flask
+
+from agent import AgentContext, AgentConfig, ModelConfig
+import models
+
+
+@pytest.fixture
+def agent_config() -> AgentConfig:
+    """Provide a minimal AgentConfig for tests."""
+
+    dummy_model = ModelConfig(
+        provider=models.ModelProvider.OLLAMA,
+        name="tiny",
+    )
+    return AgentConfig(
+        chat_model=dummy_model,
+        utility_model=dummy_model,
+        embeddings_model=dummy_model,
+        browser_model=dummy_model,
+        mcp_servers="{}",
+    )
+
+
+@pytest.fixture
+def agent_context(agent_config: AgentConfig) -> Generator[AgentContext, None, None]:
+    """Create and clean up an AgentContext for a test."""
+
+    ctx = AgentContext(config=agent_config)
+    try:
+        yield ctx
+    finally:
+        AgentContext.remove(ctx.id)
+
+
+@pytest.fixture
+def flask_app() -> Flask:
+    """Instantiate a minimal Flask app for API handlers."""
+
+    app = Flask(__name__)
+    return app
+
+
+@pytest.fixture
+def health_handler(flask_app: Flask) -> "HealthCheck":
+    """Return a HealthCheck API handler instance."""
+
+    from python.api.health import HealthCheck
+
+    return HealthCheck(flask_app, threading.Lock())
+
+
+@pytest.fixture
+def event_bus(monkeypatch) -> Generator:
+    """Yield an AsyncEventBus instance with NATS disabled."""
+
+    from python.helpers import event_bus as event_bus_module
+
+    class DummyNATS:
+        published = []
+
+        async def connect(self, url):
+            return None
+
+        async def subscribe(self, *args, **kwargs):
+            return None
+
+        async def publish(self, subject, data):
+            self.published.append((subject, data))
+
+    def dummy_init(self):
+        import asyncio as _asyncio
+        event_bus_module.AsyncIOEventEmitter.__init__(self, loop=_asyncio.get_event_loop())
+        self._nats = DummyNATS()
+        self._nats_url = "nats://localhost:4222"
+        self._nats_connected = False
+
+    monkeypatch.setattr(event_bus_module, "NATS", DummyNATS)
+    monkeypatch.setattr(event_bus_module.AsyncEventBus, "__init__", dummy_init)
+
+    event_bus_module.AsyncEventBus._instance = None
+    bus = event_bus_module.AsyncEventBus.get()
+
+    yield bus
+
+    event_bus_module.AsyncEventBus._instance = None

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,54 @@
+import asyncio
+import pickle
+import sys
+import types
+
+import pyee.asyncio
+
+# Expose AsyncIOEventEmitter at top-level "pyee" module for compatibility
+if 'pyee' not in sys.modules:
+    dummy_pyee = types.ModuleType('pyee')
+    sys.modules['pyee'] = dummy_pyee
+else:
+    dummy_pyee = sys.modules['pyee']
+
+dummy_pyee.AsyncIOEventEmitter = pyee.asyncio.AsyncIOEventEmitter
+
+from python.helpers.event_bus import AsyncEventBus
+
+
+def test_event_bus_emit_and_listener(event_bus):
+    results = []
+
+    async def listener(val):
+        results.append(val)
+
+    event_bus.on("test", listener)
+    handled = event_bus.emit("test", 123)
+
+    # allow scheduled callbacks to run
+    asyncio.get_event_loop().run_until_complete(asyncio.sleep(0.01))
+
+    assert handled is True
+    assert results == [123]
+
+
+def test_event_bus_emit_returns_false(event_bus):
+    handled = event_bus.emit("unhandled", 1)
+    assert handled is False
+
+
+def test_event_bus_on_nats(event_bus):
+    captured = []
+    event_bus.on("ping", lambda x: captured.append(x))
+
+    payload = pickle.dumps({"args": ["pong"], "kwargs": {}})
+
+    class Msg:
+        def __init__(self, data):
+            self.subject = "a0.events.ping"
+            self.data = data
+
+    asyncio.get_event_loop().run_until_complete(event_bus._on_nats(Msg(payload)))
+
+    assert captured == ["pong"]


### PR DESCRIPTION
## Summary
- add __future__ import in `AsyncEventBus`
- create fixtures for agent context, health handler, and event bus
- add tests verifying event bus emissions and NATS callbacks
- configure GitHub Actions workflow for pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ecdeb7c48328910b0f83e6366c46